### PR TITLE
Add maintainance checks

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -57,3 +57,18 @@ description = "Github service ping"
 module = "checks.core.heartbeat"
 params.url = "https://community-tc.services.mozilla.com/api/github/v1/ping"
 tags = ["taskcluster", "taskcluster-critical"]
+
+[checks.taskcluster.maintenance]
+description = "Project maintenance looks healthy."
+module = "checks.core.maintenance"
+ttl = 36000
+params.repositories = [
+    "taskcluster/taskcluster",
+    "taskcluster/taskcluster-rfcs",
+    "taskcluster/json-e",
+    "taskcluster/tc-admin",
+    "taskcluster/monopacker",
+
+    "taskcluster/slugid",
+]
+tags = ["taskcluster"]


### PR DESCRIPTION
Check for open PRs in key Taskcluster repositories.

These are the pinned repos on https://github.com/taskcluster/, plus [slugid](https://github.com/taskcluster/slugid/).

There are another 200 repos, but this may be a decent start.