### PR TITLE
Web server has no ping URL, use GraphQL endpoint

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -52,9 +52,9 @@ params.url = "https://community-tc.services.mozilla.com/api/secrets/v1/ping"
 tags = ["taskcluster", "taskcluster-critical"]
 
 [checks.web-server.ping]
-description = "Web service ping"
+description = "GraphQL ping"
 module = "checks.core.heartbeat"
-params.url = "https://community-tc.services.mozilla.com/api/web-server/v1/ping"
+params.url = "https://community-tc.services.mozilla.com/graphql?query=query%20IsLoggedIn{isLoggedIn}"
 tags = ["taskcluster", "taskcluster-critical"]
 
 [checks.web-server.heartbeat]


### PR DESCRIPTION
I pulled the branch on this https://github.com/mozilla-it/telescope-demo/pull/7

and rebased it onto main in this PR.

In the below comment I mention what I did. 

(Tagging for awareness. @jwhitlock @leplatrem)

Will close the other PR shortly.