### PR TITLE
Adding draft cert check to config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -98,3 +98,9 @@ params.client_id = "${TASKCLUSTER_CLIENT_ID}"
 params.access_token = "${TASKCLUSTER_ACCESS_TOKEN}"
 params.certificate = "${TASKCLUSTER_CERTIFICATE}"
 tags = ["taskcluster"]
+
+[checks.certficate.expiry]
+description = "Certificate expiry warning"
+module = "checks.core.certificate_expiration"
+params.url = "${TASKCLUSTER_ROOT_URL}"
+tags = ["taskcluster"]


### PR DESCRIPTION
Looking to confirm the URL desired to be tested. 
_Maybe the core check is planned on being used on multiple services/urls as different checks?_

Set to Taskcluster root url at this time here.